### PR TITLE
N°4098 - Insert text at the current cursor position instead of the begin

### DIFF
--- a/precanned-replies.js
+++ b/precanned-replies.js
@@ -68,19 +68,16 @@ function PrecannedDoSelect(sLogAttCode)
 			{
 				var sText = aJson[0].text;
 				var iPrecannedId = aJson[0].id;
-				var aLogDiv = '';
+				
 				if(IsPrecannedRepliesLegacy){
-					aLogDiv = $('#2_'+sLogAttCode);
+					var sInstanceCode = $('#2_'+sLogAttCode);
 				}
 				else{
-					aLogDiv = $('[data-role="ibo-caselog-entry-form"][data-attribute-code="'+sLogAttCode+'"] [data-role="ibo-caselog-entry-form--text-input"] textarea');
+					var sInstanceCode =  $('[data-role="ibo-caselog-entry-form"][data-attribute-code="'+sLogAttCode+'"] textarea').attr('id');
 				}
-				var sPrevVal = aLogDiv.val();
-				if (sPrevVal != '')
-				{
-					sPrevVal = '\n'+sPrevVal;
-				}
-				aLogDiv.val(sText+sPrevVal);
+				
+				CKEDITOR.instances[sInstanceCode].insertHtml(sText);
+				
 				var aFiles = aJson[0].files;
 				var index = 0;
 				while(index < aFiles.length)


### PR DESCRIPTION
Warning; it changes the default behavior slightly. Precanned replies are no longer automatically inserted at the top of the log and there's no longer a newline added.

However: it improves greatly on the expected behavior. Now, precanned replies appear at the top of the message.
But in our use case, the precanned replies are often links to guides.
So the agent actually types some info first and only then adds the precanned reply.

In this implementation, the predefined reply is inserted where the cursor was last.


BTW: it would be great to promote the possibility to add attachments a lot more in the documentation! 👍 